### PR TITLE
掘金博客灵动蓝主题 新增键盘文字标签样式

### DIFF
--- a/smart-blue.css
+++ b/smart-blue.css
@@ -186,6 +186,10 @@
   background-color: #f6f8fa;
 }
 
+/*
+  From: icewolf-sec (御坂19008号)
+  Description: 新增HTML5 <kbd> 键盘文字标签样式
+*/
 .markdown-body kbd{
   color: white;
   background-color: #135ce0;

--- a/smart-blue.css
+++ b/smart-blue.css
@@ -185,3 +185,14 @@
 .markdown-body table tr:nth-child(2n) {
   background-color: #f6f8fa;
 }
+
+.markdown-body kbd{
+  color: white;
+  background-color: #135ce0;
+  border: 1px solid #135ce0;
+  border-radius: 5px;
+  padding: 2px;
+  font-weight: bold;
+  margin: auto 5px auto;
+  font-size: small;
+}


### PR DESCRIPTION
在CSS文件中新创建了一个HTML5 &lt;kbd&gt;标签样式。该标签在博客中的场景主要用于表示按钮或键盘上的文字。
用法：&lt;kbd&gt;文字&lt;/kbd&gt;        详见：[HTML &lt;kbd&gt; 标签 | 菜鸟教程](https://www.runoob.com/tags/tag-kbd.html)
举例来说：
  1)    在VMware主界面中点击按钮 <kbd>文件</kbd> --->  <kbd>创建虚拟机</kbd> 打开新建虚拟机窗口    （创建虚拟机）
  2)    点击安装界面上的 <kbd>现在安装</kbd>按钮进入安装界面    （安装软件）
  3)    打开 <kbd>设置</kbd> ---> <kbd>主题</kbd> ---> <kbd>壁纸</kbd>     （设置电脑壁纸）
  ......
该标签样式为蓝底白字圆角方框，契合博客主题风格，望采纳！